### PR TITLE
Fix typos and CSS variable syntax

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2,8 +2,8 @@
 @font-face { src: url("../assets/fonts/ABChanelRG.ttf") format("truetype"); font-family: ABChanelRG; }
 
 :root {
-  --primary-color: rgba(0,0,0,1.0);;
-  --secondary-color: rgba(0,0,0,0.1);;
+  --primary-color: rgba(0,0,0,1.0);
+  --secondary-color: rgba(0,0,0,0.1);
 }
 
 body {

--- a/projects.html
+++ b/projects.html
@@ -20,13 +20,13 @@
   <section>
     <h5 class="header">Projects</h5>
     <h6 class="header">Decision Game App</h6>
-    <p>An decision-map-based android game following a short storyline that is set upon an explosion on a moon base due to an unknown technical failure, and follows a character with the main goal of escaping the planet. The idea of this game was to introduce basic concepts learned in Computer Science through an interactive user-interface.</p>
+    <p>A decision-map-based android game following a short storyline that is set upon an explosion on a moon base due to an unknown technical failure, and follows a character with the main goal of escaping the planet. The idea of this game was to introduce basic concepts learned in Computer Science through an interactive user-interface.</p>
     <img src="/assets/img/meldown.png" alt="meltdown">
     <p class="light-text">Technologies : Android | Java</p>
     <p class="light-text">Tools : Android Studio | Adobe XD | GitHub </p>
     <a class="link-btn" href="https://github.com/carmelo-varela/decision-game" target="_blank">DISCOVER</a>
     <h6 class="header">Fuel Price App</h6>
-    <p>A web-based application with the goal of allowing users to search, compare and fint the cheapest fuel prices on a map-based interface.</p>
+    <p>A web-based application with the goal of allowing users to search, compare and find the cheapest fuel prices on a map-based interface.</p>
     <img src="/assets/img/fuelo.png" alt="fuelo">
     <p class="light-text">Technologies : HTML | CSS | JavaScript | NodeJS | PostgreSQL</p>
     <p class="light-text">Tools : Visual Studio Code | Adobe XD | GitHub | JSDoc </p>


### PR DESCRIPTION
## Summary
- clean up CSS custom properties
- fix typos in project descriptions

## Testing
- `npx --yes htmlhint *.html`
- `npx --yes csslint css/index.css` *(fails: Expected RBRACE errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fe086d9ec8331bf4539a28ce6e2fe