### PR TITLE
Use Google Geist font across site

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1,5 +1,3 @@
-@font-face { src: url("../assets/fonts/ABChanelSB.ttf") format("truetype"); font-family: ABChanelSB; }
-@font-face { src: url("../assets/fonts/ABChanelRG.ttf") format("truetype"); font-family: ABChanelRG; }
 
 :root {
   --primary-color: rgba(0,0,0,1.0);
@@ -7,7 +5,7 @@
 }
 
 body {
-  font-family: Helvetica, sans-serif;
+  font-family: 'Geist', sans-serif;
   font-weight: 300;
   line-height: 1.65;
   margin: 0;
@@ -45,7 +43,7 @@ header {
 }
 
 .header {
-  font-family: "ABChanelSB";
+  font-family: 'Geist', sans-serif;
   margin: 0 0 1rem;
 }
 
@@ -54,7 +52,7 @@ header {
   margin-right: 2rem;
   padding-bottom: 1.75rem;
   border-bottom: 4px solid transparent;
-  font-family: "ABChanelRG";
+  font-family: 'Geist', sans-serif;
 }
 
 .nav-link:last-child {
@@ -91,12 +89,12 @@ footer {
 }
 
 footer > h6 {
-  font-family: "ABChanelRG";
+  font-family: 'Geist', sans-serif;
 }
 
 .primary-btn {
   font-size: 0.75rem;
-  font-family: "ABChanelSB";
+  font-family: 'Geist', sans-serif;
   padding: 0.75rem;
   border: 1px solid #ededed;
   margin: 2rem 0;
@@ -111,7 +109,7 @@ footer > h6 {
 .link-btn {
   display: inline-block;
   font-size: 0.75rem;
-  font-family: "ABChanelSB";
+  font-family: 'Geist', sans-serif;
   padding: 0.75rem;
   color: #ffffff;
   background-color: var(--primary-color);

--- a/experience.html
+++ b/experience.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/index.css">
   <link rel="shortcut icon" href="assets/img/favicon.svg" type="image/x-icon">
   <title>Carmelo Varela</title>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/index.css">
   <link rel="shortcut icon" href="assets/img/favicon.svg" type="image/x-icon">
   <title>Carmelo Varela</title>

--- a/projects.html
+++ b/projects.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/index.css">
   <link rel="shortcut icon" href="assets/img/favicon.svg" type="image/x-icon">
   <title>Carmelo Varela</title>


### PR DESCRIPTION
## Summary
- use Geist from Google Fonts instead of local fonts
- update styles to rely on Geist
- add Google Fonts link to all HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68600bb1670883319526ab10a5e09246