### PR TITLE
Make nav links and headings semibold

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -44,11 +44,13 @@ header {
 
 .header {
   font-family: 'Geist', sans-serif;
+  font-weight: 600;
   margin: 0 0 1rem;
 }
 
 .nav-link {
   font-size: 0.7rem;
+  font-weight: 600;
   margin-right: 2rem;
   padding-bottom: 1.75rem;
   border-bottom: 4px solid transparent;


### PR DESCRIPTION
## Summary
- use `font-weight: 600` on `.header` for heading tags
- use `font-weight: 600` on `.nav-link`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600cd882f88331aee8d9a46899b4c7