### PR TITLE
Remove email contact link

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@
   </section>
   <section>
     <h5 class="header">Get in touch</h5>
-    <a class="primary-btn" href="mailto:varelaenrico@gmail.com" target="_blank">Email</a>
     <a class="primary-btn" href="https://www.linkedin.com/in/carmelovarela" target="_blank">Linkedin</a>
     <a class="primary-btn" href="https://github.com/carmelo-varela" target="_blank">Github</a>
   </section>


### PR DESCRIPTION
## Summary
- remove the email link from the "Get in touch" section of the main page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68609b36361c83319152075f1337ce1e